### PR TITLE
Support WAD2AI enablement without requiring any pre-configuration

### DIFF
--- a/DiagPublicConfigTemplateCS.xml
+++ b/DiagPublicConfigTemplateCS.xml
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<PublicConfig xmlns="http://schemas.microsoft.com/ServiceHosting/2010/10/DiagnosticsConfiguration">
+  <WadCfg>
+    <DiagnosticMonitorConfiguration overallQuotaInMB="4096" >
+      <DiagnosticInfrastructureLogs scheduledTransferLogLevelFilter="Error" />
+      <Directories scheduledTransferPeriod="PT1M">
+        <IISLogs containerName="wad-iis-logfiles" />
+        <FailedRequestLogs containerName="wad-failedrequestlogs" />
+      </Directories>
+      <PerformanceCounters scheduledTransferPeriod="PT1M">
+        <PerformanceCounterConfiguration counterSpecifier="\Memory\Available MBytes" sampleRate="PT3M" />
+        <PerformanceCounterConfiguration counterSpecifier="\Web Service(_Total)\ISAPI Extension Requests/sec" sampleRate="PT3M" />
+        <PerformanceCounterConfiguration counterSpecifier="\Web Service(_Total)\Bytes Total/Sec" sampleRate="PT3M" />
+        <PerformanceCounterConfiguration counterSpecifier="\ASP.NET Applications(__Total__)\Requests/Sec" sampleRate="PT3M" />
+        <PerformanceCounterConfiguration counterSpecifier="\ASP.NET Applications(__Total__)\Errors Total/Sec" sampleRate="PT3M" />
+        <PerformanceCounterConfiguration counterSpecifier="\ASP.NET\Requests Queued" sampleRate="PT3M" />
+        <PerformanceCounterConfiguration counterSpecifier="\ASP.NET\Requests Rejected" sampleRate="PT3M" />
+        <PerformanceCounterConfiguration counterSpecifier="\Processor(_Total)\% Processor Time" sampleRate="PT3M" />
+      </PerformanceCounters>
+      <WindowsEventLog scheduledTransferPeriod="PT1M">
+        <DataSource name="Application!*[System[(Level=1 or Level=2 or Level=3)]]" />
+        <DataSource name="Windows Azure!*[System[(Level=1 or Level=2 or Level=3 or Level=4)]]" />
+      </WindowsEventLog>
+      <CrashDumps>
+        <CrashDumpConfiguration processName="WaIISHost.exe" />
+        <CrashDumpConfiguration processName="WaWorkerHost.exe" />
+        <CrashDumpConfiguration processName="w3wp.exe" />
+      </CrashDumps>
+      <Logs scheduledTransferPeriod="PT1M" scheduledTransferLogLevelFilter="Error" />
+    </DiagnosticMonitorConfiguration>
+  </WadCfg>
+</PublicConfig>

--- a/DiagPublicConfigTemplateVM.xml
+++ b/DiagPublicConfigTemplateVM.xml
@@ -1,0 +1,42 @@
+<WadCfg>
+  <DiagnosticMonitorConfiguration overallQuotaInMB="4096" xmlns="http://schemas.microsoft.com/ServiceHosting/2010/10/DiagnosticsConfiguration" >
+    <Metrics>
+      <MetricAggregation scheduledTransferPeriod="PT1H" />
+      <MetricAggregation scheduledTransferPeriod="PT1M" />
+    </Metrics>
+    <DiagnosticInfrastructureLogs scheduledTransferPeriod="PT1M" scheduledTransferLogLevelFilter="Warning" />
+    <PerformanceCounters>
+      <PerformanceCounterConfiguration counterSpecifier="\Processor(_Total)\% Processor Time" sampleRate="PT15S" unit="Percent">
+        <annotation displayName="CPU percentage guest OS" locale="en-us" />
+      </PerformanceCounterConfiguration>
+      <PerformanceCounterConfiguration counterSpecifier="\System\Processes" sampleRate="PT15S" unit="Count">
+        <annotation displayName="Processes" locale="en-us" />
+      </PerformanceCounterConfiguration>
+      <PerformanceCounterConfiguration counterSpecifier="\Memory\Available Bytes" sampleRate="PT15S" unit="Bytes">
+        <annotation displayName="Memory available" locale="en-us" />
+      </PerformanceCounterConfiguration>
+      <PerformanceCounterConfiguration counterSpecifier="\Process(_Total)\% Processor Time" sampleRate="PT15S" unit="Percent">
+        <annotation displayName="Process total time" locale="en-us" />
+      </PerformanceCounterConfiguration>
+      <PerformanceCounterConfiguration counterSpecifier="\PhysicalDisk(_Total)\Disk Read Bytes/sec" sampleRate="PT15S" unit="BytesPerSecond">
+        <annotation displayName="Disk read guest OS" locale="en-us" />
+      </PerformanceCounterConfiguration>
+      <PerformanceCounterConfiguration counterSpecifier="\PhysicalDisk(_Total)\Disk Write Bytes/sec" sampleRate="PT15S" unit="BytesPerSecond">
+        <annotation displayName="Disk write guest OS" locale="en-us" />
+      </PerformanceCounterConfiguration>
+    </PerformanceCounters>
+    <WindowsEventLog scheduledTransferPeriod="PT1M">
+      <DataSource name="Security!*[System[(Level = 1) or (Level = 2)]]" />
+      <DataSource name="Application!*[System[(Level = 1) or (Level = 2)]]" />
+      <DataSource name="System!*[System[(Level = 1) or (Level = 2)]]" />
+    </WindowsEventLog>
+    <EtwProviders>
+      <EtwEventSourceProviderConfiguration provider="Service Control Manager">
+        <DefaultEvents />
+      </EtwEventSourceProviderConfiguration>
+      <EtwManifestProviderConfiguration provider="3000B92B-CA8B-4269-90EA-C4185EE09E92" scheduledTransferPeriod="PT1M">
+        <DefaultEvents eventDestination="WindowsAzureGuestAgent" />
+      </EtwManifestProviderConfiguration>
+    </EtwProviders>
+  </DiagnosticMonitorConfiguration>
+</WadCfg>


### PR DESCRIPTION
Added two configuration templates for Cloud Service and VM respectively, so enablement now works even if Azure Diagnostics has not been previously enabled for the VM.
If Azure Diagnostic is already enabled for the VM then WAD2AI wiring will be added incrementally to the existing configuration, otherwise the bootstrap template configuration will be used with decent default settings.

Also, the script is now re-entrant and can be executed repeatedly to recover potential errors from wrong manual configuration.
